### PR TITLE
Removes built_at

### DIFF
--- a/build.go
+++ b/build.go
@@ -70,10 +70,6 @@ func Build(entryResolver EntryResolver, installProcess InstallProcess, pythonPat
 		logger.Action("Completed in %s", duration.Round(time.Millisecond))
 		logger.Break()
 
-		venvLayer.Metadata = map[string]interface{}{
-			"built_at": clock.Now().Format(time.RFC3339Nano),
-		}
-
 		pythonPathDir, err := pythonPathProcess.Execute(venvDir)
 		if err != nil {
 			return packit.BuildResult{}, err

--- a/build_test.go
+++ b/build_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
@@ -33,10 +32,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		installProcess    *fakes.InstallProcess
 		sbomGenerator     *fakes.SBOMGenerator
 		pythonPathProcess *fakes.PythonPathLookupProcess
-		clock             chronos.Clock
 
-		timeStamp time.Time
-		buffer    *bytes.Buffer
+		buffer *bytes.Buffer
 
 		build        packit.BuildFunc
 		buildContext packit.BuildContext
@@ -66,17 +63,12 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		buffer = bytes.NewBuffer(nil)
 
-		timeStamp = time.Now()
-		clock = chronos.NewClock(func() time.Time {
-			return timeStamp
-		})
-
 		build = poetryinstall.Build(
 			entryResolver,
 			installProcess,
 			pythonPathProcess,
 			sbomGenerator,
-			clock,
+			chronos.DefaultClock,
 			scribe.NewEmitter(buffer),
 		)
 
@@ -130,10 +122,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(venvLayer.SharedEnv["PYTHONPATH.prepend"]).To(Equal("some-python-path"))
 		Expect(venvLayer.SharedEnv["PYTHONPATH.delim"]).To(Equal(":"))
 		Expect(venvLayer.SharedEnv["POETRY_VIRTUALENVS_PATH.default"]).To(Equal(filepath.Join(layersDir, "poetry-venv")))
-
-		Expect(venvLayer.Metadata).To(Equal(map[string]interface{}{
-			"built_at": timeStamp.Format(time.RFC3339Nano),
-		}))
 
 		Expect(venvLayer.SBOM.Formats()).To(Equal([]packit.SBOMFormat{
 			{
@@ -256,10 +244,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(venvLayer.SharedEnv["PYTHONPATH.prepend"]).To(Equal("some-python-path"))
 			Expect(venvLayer.SharedEnv["PYTHONPATH.delim"]).To(Equal(":"))
 			Expect(venvLayer.SharedEnv["POETRY_VIRTUALENVS_PATH.default"]).To(Equal(filepath.Join(layersDir, "poetry-venv")))
-
-			Expect(venvLayer.Metadata).To(Equal(map[string]interface{}{
-				"built_at": timeStamp.Format(time.RFC3339Nano),
-			}))
 
 			cacheLayer := layers[1]
 			Expect(cacheLayer.Name).To(Equal("cache"))


### PR DESCRIPTION
Resolves #19 

This buildpack currently does not reuse a layer but the built_at tag has still been removed for consistency sake.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
