### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Poetry Install Cloud Native Buildpack
 ## `gcr.io/paketo-buildpacks/poetry-install`
 
-The Paketo Poetry Install Buildpack is a Cloud Native Buildpack that installs
+The Paketo Buildpack for Poetry Install is a Cloud Native Buildpack that installs
 packages using [Poetry](https://python-poetry.org/) and makes the installed packages
 available to the application.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/poetry-install"
-  name = "Paketo Poetry Install Buildpack"
+  name = "Paketo Buildpack for Poetry Install"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
 [metadata]


### PR DESCRIPTION
Renames 'Paketo Poetry Install Buildpack' to 'Paketo Buildpack for Poetry Install'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
