### PR TITLE
Revert "Add targets to buildpack.toml"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,11 +11,3 @@ api = "0.7"
 
 [[stacks]]
   id = "*"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "18.04"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "22.04"


### PR DESCRIPTION
This reverts commit 56ce6ff38d8418a5a2b53da2d57461b7d8eb07f6.

 - This change was made in error. We can re-evaluate introducing targets when we bump the buildpack API spec.
